### PR TITLE
Updated meson build instructions (#402)

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ But we recommend to use [Guix Home](https://guix.gnu.org/manual/devel/en/html_no
 - `libnotify`
 
 ```zsh
-meson build --prefix=/usr
+meson setup build --prefix=/usr
 ninja -C build
 meson install -C build
 ```


### PR DESCRIPTION
Just switched from "meson build --prefix=/usr" to "meson setup build --prefix=/usr " as while compiling I received this warning:

WARNING: Running the setup command as `meson [options]` instead of `meson setup [options]` is ambiguous and deprecated.